### PR TITLE
fix: support decoding data URL in Node < v16

### DIFF
--- a/src/wasm-helper.ts
+++ b/src/wasm-helper.ts
@@ -9,10 +9,18 @@ export const id = "/__vite-plugin-wasm-helper";
 const wasmHelper = async (opts = {}, url: string) => {
   let result: WebAssembly.WebAssemblyInstantiatedSource;
   if (url.startsWith("data:")) {
-    const binaryString = atob(url.replace(/^data:.*?base64,/, ""));
-    const bytes = new Uint8Array(binaryString.length);
-    for (let i = 0; i < binaryString.length; i++) {
-      bytes[i] = binaryString.charCodeAt(i);
+    const urlContent = url.replace(/^data:.*?base64,/, "");
+    let bytes;
+    if (typeof Buffer === "function" && typeof Buffer.from === "function") {
+      bytes = Buffer.from(urlContent, "base64");
+    } else if (typeof atob === "function") {
+      const binaryString = atob(urlContent);
+      bytes = new Uint8Array(binaryString.length);
+      for (let i = 0; i < binaryString.length; i++) {
+        bytes[i] = binaryString.charCodeAt(i);
+      }
+    } else {
+      throw new Error("Cannot decode base64-encoded data URL");
     }
     result = await WebAssembly.instantiate(bytes, opts);
   } else {


### PR DESCRIPTION
I want to publish code that works on Node.js and web browsers alike, and I would like to support Node v14, which [reaches EOL on April 2023](https://nodejs.org/en/about/releases/). However, Node < v16 do not provide a global `atob()` function for decoding base64 strings, and must use `Buffer.from()` instead. (See [docs for `atob()`](https://nodejs.org/api/globals.html#atobdata))

Furthermore, `Buffer.from(str, 'base64').toString()` is much faster than `atob()` in Node:

```console
// Node v16.15.1

> var bigStr = btoa('1234567890abcdefghijklmnopqrstuvwxyz'.repeat(100000));
> console.time('atob'); atob(bigStr); console.timeEnd('atob');
atob: 117.196ms
> console.time('Buffer.from'); Buffer.from(bigStr, 'base64').toString(); console.timeEnd('Buffer.from');
Buffer.from: 9.797ms
```

This is because `atob()` is [intentionally unoptimized](https://github.com/nodejs/node/blob/6975dd14253e936509e2a68b293101fa234e53af/lib/buffer.js#L1259-L1261). (See [rationale](https://github.com/nodejs/node/pull/38433#issuecomment-828426932))

Thus, we should prefer `Buffer.from()` whenever it is available.

This PR uses `Buffer.from()` if it is available, and `atob()` otherwise. In the rare event that neither exists, the code throws an Error.