### PR TITLE
Initial attempt at Vitest support

### DIFF
--- a/src/esbuild-plugin.ts
+++ b/src/esbuild-plugin.ts
@@ -23,7 +23,7 @@ export function esbuildPlugin(): Plugin {
           contents: `
 const wasmUrl = "${dataUri}";
 const initWasm = ${wasmHelper.code};
-${await generateGlueCode(args.path, { initWasm: "initWasm", wasmUrl: "wasmUrl" })}
+${await generateGlueCode(args.path, build.initialOptions.absWorkingDir, { initWasm: "initWasm", wasmUrl: "wasmUrl" })}
 `,
           loader: "js",
           resolveDir: path.dirname(args.path)

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ import { generateGlueCode } from "./wasm-parser";
 import * as wasmHelper from "./wasm-helper";
 
 export default function wasm(): any {
+  let rootPath: string;
+
   return <Plugin>{
     name: "vite-plugin-wasm",
     enforce: "pre",
@@ -19,6 +21,8 @@ export default function wasm(): any {
         // Allow usage of top-level await during development build (not affacting the production build)
         config.optimizeDeps.esbuildOptions.target = "esnext";
       }
+
+      rootPath = config.root;
     },
     resolveId(id) {
       if (id === wasmHelper.id) {
@@ -40,7 +44,7 @@ export default function wasm(): any {
       return `
 import __vite__wasmUrl from ${JSON.stringify(wasmUrlUrl)};
 import __vite__initWasm from "${wasmHelper.id}"
-${await generateGlueCode(id, { initWasm: "__vite__initWasm", wasmUrl: "__vite__wasmUrl" })}
+${await generateGlueCode(id, rootPath, { initWasm: "__vite__initWasm", wasmUrl: "__vite__wasmUrl" })}
 `;
     }
   };

--- a/src/wasm-parser.ts
+++ b/src/wasm-parser.ts
@@ -32,6 +32,7 @@ export async function parseWasm(wasmFilePath: string): Promise<WasmInfo> {
 
 export async function generateGlueCode(
   wasmFilePath: string,
+  rootPath: string,
   names: { initWasm: string; wasmUrl: string }
 ): Promise<string> {
   const { imports, exports } = await parseWasm(wasmFilePath);
@@ -49,7 +50,7 @@ const __vite__wasmModule = await ${names.initWasm}({ ${imports
       ({ from, names }, i) =>
         `${JSON.stringify(from)}: { ${names.map((name, j) => `${name}: __vite__wasmImport_${i}_${j}`).join(", ")} }`
     )
-    .join(", ")} }, ${names.wasmUrl});
+    .join(", ")} }, ${names.wasmUrl}, ${JSON.stringify(rootPath)});
 ${exports
   .map(name => `export ${name === "default" ? "default" : `const ${name} =`} __vite__wasmModule.${name};`)
   .join("\n")}`;


### PR DESCRIPTION
This PR is an initial stab at enabling support for server-side rendering, which is needed for vite-plugin-wasm to work in Vitest.

I haven't tested this in detail - e.g. whether it will work in a normal Vite SSR context. But I thought it would be good to get early feedback on the approach before investing too much time.