### PR TITLE
Fix `URL` name collision

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ export default function wasm(): any {
       const wasmUrlUrl = id + "?url";
 
       return `
+URL = globalThis.URL
 import __vite__wasmUrl from ${JSON.stringify(wasmUrlUrl)};
 import __vite__initWasm from "${wasmHelper.id}"
 ${await generateGlueCode(id, { initWasm: "__vite__initWasm", wasmUrl: "__vite__wasmUrl" })}


### PR DESCRIPTION
I am using wasm package in Svelte app that exports class URL. Vite generates code `""+new URL("...")`, and because of wasm package's URL class `new URL` is undefined at this point. Adding `URL = globalThis.URL` reserves name 'URL' for a global URL object in this context, and `URL` class imported from wasm package gets another name in compiled code and works as expected.