### PR TITLE
Fix types for "moduleResolution": "bundler"

### DIFF
--- a/exports/types.d.ts
+++ b/exports/types.d.ts
@@ -1,0 +1,2 @@
+export * from "../dist/index";
+export { default } from "../dist/index";

--- a/package.json
+++ b/package.json
@@ -2,8 +2,10 @@
   "name": "vite-plugin-wasm",
   "version": "3.2.2",
   "description": "Add WebAssembly ESM integration (aka. Webpack's `asyncWebAssembly`) to Vite and support `wasm-pack` generated modules.",
-  "main": "dist/index.js",
+  "types": "./dist/index.d.ts",
+  "main": "./dist/index.js",
   "exports": {
+    "types": "./exports/types.d.ts",
     "import": "./exports/import.mjs",
     "require": "./exports/require.cjs"
   },


### PR DESCRIPTION
Also note that Vite has since removed types for `*.wasm` files. So you can now just add a proper `.wasm.d.ts` or `.d.wasm.ts` (With `allowArbitraryExtensions`) for them, or an a [shorthand ambient declaration](https://www.typescriptlang.org/docs/handbook/modules.html#shorthand-ambient-modules) in a .d.ts file, if you really want to have `any` everywhere, to type the wasm module.