### PR TITLE
Keep the CommonJS format for now.

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 /** @type {import('ts-jest/dist/types').JestConfigWithTsJest} */
-export default {
+module.exports = {
   verbose: true,
   transform: {
     "^.+\\.ts?$": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "vite-plugin-wasm",
   "version": "3.4.0",
   "description": "Add WebAssembly ESM integration (aka. Webpack's `asyncWebAssembly`) to Vite and support `wasm-pack` generated modules.",
-  "type": "module",
   "types": "./exports/require.d.cts",
   "main": "./exports/require.cjs",
   "module": "./exports/import.mjs",


### PR DESCRIPTION
Keep the CommonJS format for now.
the ESModule format will throw error:
SyntaxError: The requested module '../dist/index.js' does not provide an export named 'default'